### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "echo hello word"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@
 
 #### Avatar:
 <img src="https://user-images.githubusercontent.com/59664899/72993072-5eaf9c80-3dba-11ea-8ddf-c98f22ee6fe9.jpg" width="200" height="250" /> 
+
+[![Run on Repl.it](https://repl.it/badge/github/LandenSJones/3013-ALG-Jones)](https://repl.it/github/LandenSJones/3013-ALG-Jones)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@LandenSJones/3013-ALG-Jones).